### PR TITLE
version 0.2.7: 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blitz-utils"
-version = "0.2.6"
+version = "0.2.7"
 authors = [{ name = "Jylpah", email = "jylpah@gmail.com" }]
 description = "Python utils for Wargaming's World of Tanks Blitz game "
 readme = "README.md"

--- a/src/blitzutils/wg_api.py
+++ b/src/blitzutils/wg_api.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Extra, root_validator, validator, Field
 from aiohttp import ClientTimeout
 from urllib.parse import quote
 from collections import defaultdict
+from sortedcollections import SortedDict  # type: ignore
 
 from pyutils import JSONExportable, TypeExcludeDict, Idx, BackendIndexType, BackendIndex, ThrottledClientSession
 from pyutils.utils import epoch_now, get_url_JSON_model
@@ -497,7 +498,7 @@ class WGApiWoTBlitzPlayerAchievements(WGApiWoTBlitz):
 
 
 class WGApiTankopedia(WGApiWoTBlitz):
-    data: dict[str, WGTank] = Field(default=dict(), alias="d")
+    data: SortedDict[str, WGTank] = Field(default=SortedDict(int), alias="d")
     # userStr	: dict[str, str] | None = Field(default=None, alias='s')
 
     _exclude_export_DB_fields = {"userStr": True}

--- a/src/blitzutils/wg_api.py
+++ b/src/blitzutils/wg_api.py
@@ -526,6 +526,11 @@ class WGApiTankopedia(WGApiWoTBlitz):
         self.update_count()
         return wgtank
 
+    @validator("data", pre=False)
+    def validate_data(cls, value) -> SortedDict[str, WGTank]:
+        if type(value) is not SortedDict:
+            return SortedDict(int, **value)
+
 
 class WoTBlitzTankString(JSONExportable):
     code: str = Field(default=..., alias="_id")


### PR DESCRIPTION
- `WGApiTankopedia()`: 
  - Sort tanks according to `int(tank_id)`
  - Test for maintaining the sort order